### PR TITLE
fix: failed to create python3 venv on Windows

### DIFF
--- a/shared/utils.go
+++ b/shared/utils.go
@@ -2,11 +2,8 @@ package shared
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -108,54 +105,6 @@ func call(fn reflect.Value, args []reflect.Value) (interface{}, error) {
 	}
 }
 
-// EnsurePython3Venv ensures python3 venv for hashicorp python plugin
-// venvDir should be directory path of target venv
-func EnsurePython3Venv(venvDir string, packages ...string) (python3 string, err error) {
-	if runtime.GOOS == "windows" {
-		python3 = filepath.Join(venvDir, "Scripts", "python3.exe")
-	} else {
-		python3 = filepath.Join(venvDir, "bin", "python3")
-	}
-
-	log.Info().
-		Str("python3", python3).
-		Strs("packages", packages).
-		Msg("ensure python3 venv")
-
-	// check if python3 venv is available
-	if err := exec.Command(python3, "--version").Run(); err != nil {
-		// python3 venv not available, create one
-		// check if system python3 is available
-		if err := execCommand("python3", "--version"); err != nil {
-			return "", errors.Wrap(err, "python3 not found")
-		}
-
-		// check if .venv exists
-		if _, err := os.Stat(venvDir); err == nil {
-			// .venv exists, remove first
-			if err := execCommand("rm", "-rf", venvDir); err != nil {
-				return "", errors.Wrap(err, "remove existed venv failed")
-			}
-		}
-
-		// create python3 .venv
-		// notice: --symlinks should be specified for windows
-		// https://github.com/actions/virtual-environments/issues/2690
-		if err := execCommand("python3", "-m", "venv", "--symlinks", venvDir); err != nil {
-			return "", errors.Wrap(err, "create python3 venv failed")
-		}
-	}
-
-	for _, pkg := range packages {
-		err := InstallPythonPackage(python3, pkg)
-		if err != nil {
-			return python3, errors.Wrap(err, fmt.Sprintf("pip install %s failed", pkg))
-		}
-	}
-
-	return python3, nil
-}
-
 func InstallPythonPackage(python3 string, pkg string) (err error) {
 	var pkgName string
 	if strings.Contains(pkg, "==") {
@@ -198,23 +147,6 @@ func InstallPythonPackage(python3 string, pkg string) (err error) {
 		"--quiet", "--disable-pip-version-check")
 	if err != nil {
 		return errors.Wrap(err, "pip3 install package failed")
-	}
-
-	return nil
-}
-
-func execCommand(cmdName string, args ...string) error {
-	cmd := exec.Command(cmdName, args...)
-	log.Info().Str("cmd", cmd.String()).Msg("exec command")
-
-	// print output with colors
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-	if err != nil {
-		log.Error().Err(err).Msg("exec command failed")
-		return err
 	}
 
 	return nil

--- a/shared/utils_unix.go
+++ b/shared/utils_unix.go
@@ -1,0 +1,72 @@
+// +build darwin linux
+
+package shared
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// EnsurePython3Venv ensures python3 venv for hashicorp python plugin
+// venvDir should be directory path of target venv
+func EnsurePython3Venv(venvDir string, packages ...string) (python3 string, err error) {
+	python3 = filepath.Join(venvDir, "bin", "python3")
+
+	log.Info().
+		Str("python3", python3).
+		Strs("packages", packages).
+		Msg("ensure python3 venv")
+
+	// check if python3 venv is available
+	if err := exec.Command(python3, "--version").Run(); err != nil {
+		// python3 venv not available, create one
+		// check if system python3 is available
+		if err := execCommand("python3", "--version"); err != nil {
+			return "", errors.Wrap(err, "python3 not found")
+		}
+
+		// check if .venv exists
+		if _, err := os.Stat(venvDir); err == nil {
+			// .venv exists, remove first
+			if err := execCommand("rm", "-rf", venvDir); err != nil {
+				return "", errors.Wrap(err, "remove existed venv failed")
+			}
+		}
+
+		// create python3 .venv
+		if err := execCommand("python3", "-m", "venv", venvDir); err != nil {
+			return "", errors.Wrap(err, "create python3 venv failed")
+		}
+	}
+
+	for _, pkg := range packages {
+		err := InstallPythonPackage(python3, pkg)
+		if err != nil {
+			return python3, errors.Wrap(err, fmt.Sprintf("pip install %s failed", pkg))
+		}
+	}
+
+	return python3, nil
+}
+
+func execCommand(cmdName string, args ...string) error {
+	cmd := exec.Command(cmdName, args...)
+	log.Info().Str("cmd", cmd.String()).Msg("exec command")
+
+	// print output with colors
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		log.Error().Err(err).Msg("exec command failed")
+		return err
+	}
+
+	return nil
+}

--- a/shared/utils_windows.go
+++ b/shared/utils_windows.go
@@ -1,0 +1,86 @@
+// +build windows
+
+package shared
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// EnsurePython3Venv ensures python3 venv for hashicorp python plugin
+// venvDir should be directory path of target venv
+func EnsurePython3Venv(venvDir string, packages ...string) (python3 string, err error) {
+	python3 = filepath.Join(venvDir, "Scripts", "python3.exe")
+	log.Info().
+		Str("python3", python3).
+		Strs("packages", packages).
+		Msg("ensure python3 venv")
+
+	// check if python3 venv is available
+	if err := execCommand(python3, "--version"); err != nil {
+		// python3 venv not available, create one
+		// check if system python3 is available
+		if err := execCommand("python3", "--version"); err != nil {
+			return "", errors.Wrap(err, "python3 not found")
+		}
+
+		// check if .venv exists
+		if _, err := os.Stat(venvDir); err == nil {
+			// .venv exists, remove first
+			if err := execCommand("del", "/q", venvDir); err != nil {
+				return "", errors.Wrap(err, "remove existed venv failed")
+			}
+		}
+
+		// create python3 .venv
+		// notice: --symlinks should be specified for windows
+		// https://github.com/actions/virtual-environments/issues/2690
+		if err := execCommand("python3", "-m", "venv", "--symlinks", venvDir); err != nil {
+			// fix: failed to symlink on Windows
+			log.Warn().Msg("failed to create python3 .venv by using --symlinks, try to use --copies")
+			if err := execCommand("python3", "-m", "venv", "--copies", venvDir); err != nil {
+				return "", errors.Wrap(err, "create python3 venv failed")
+			}
+		}
+
+		// fix: python3 not existed on Windows
+		if _, err := os.Stat(python3); err != nil {
+			python3 = filepath.Join(venvDir, "Scripts", "python.exe")
+		}
+	}
+
+	for _, pkg := range packages {
+		err := InstallPythonPackage(python3, pkg)
+		if err != nil {
+			return python3, errors.Wrap(err, fmt.Sprintf("pip install %s failed", pkg))
+		}
+	}
+
+	return python3, nil
+}
+
+func execCommand(cmdName string, args ...string) error {
+	// "cmd /c" carries out the command specified by string and then stops
+	// refer: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd
+	cmdStr := fmt.Sprintf("%s %s", cmdName, strings.Join(args, " "))
+	cmd := exec.Command("cmd", "/c", cmdStr)
+	log.Info().Str("cmd", cmd.String()).Msg("exec command")
+
+	// print output with colors
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		log.Error().Err(err).Msg("exec command failed")
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
解决windows端生成脚手架失败问题
```
.\hrp.exe startproject demo --py
6:58PM INF Set log to color console other than JSON format.
6:58PM ??? Set log level
6:58PM INF create new scaffold project force=false pluginType=py projectName=demo
6:58PM INF create folder path=demo
6:58PM INF create folder path="demo\\har"
6:58PM INF create file path="demo\\har\\.keep"
6:58PM INF create folder path="demo\\testcases"
6:58PM INF create folder path="demo\\reports"
6:58PM INF create file path="demo\\reports\\.keep"
6:58PM INF create file path="demo\\.gitignore"
6:58PM INF create file path="demo\\.env"
6:58PM INF create file path="demo\\testcases\\demo_with_funplugin.json"
6:58PM INF create file path="demo\\testcases\\demo_requests.yml"
6:58PM INF create file path="demo\\testcases\\demo_ref_testcase.yml"
6:58PM INF start to create hashicorp python plugin
6:58PM INF create file path="demo\\debugtalk.py"
6:58PM INF ensure python3 venv packages=["funppy"] python3="C:\\Users\\bytedance\\.hrp\\venv\\Scripts\\python3.exe"
6:58PM INF exec command cmd="python3 --version"
6:58PM ERR exec command failed error="exec: \"python3\": executable file not found in %PATH%"
6:58PM ERR create scaffold project failed error="ensure python3 venv failed: python3 not found: exec: \"python3\": executable file not found in %PATH%"
```
更改后：
```
$ .\hrp.exe startproject demo --py
6:47PM INF Set log to color console other than JSON format.
6:47PM ??? Set log level
6:47PM INF create new scaffold project force=false pluginType=py projectName=demo
6:47PM INF create folder path=demo
6:47PM INF create folder path="demo\\har"
6:47PM INF create file path="demo\\har\\.keep"
6:47PM INF create folder path="demo\\testcases"
6:47PM INF create folder path="demo\\reports"
6:47PM INF create file path="demo\\reports\\.keep"
6:47PM INF create file path="demo\\.gitignore"
6:47PM INF create file path="demo\\.env"
6:47PM INF create file path="demo\\testcases\\demo_with_funplugin.json"
6:47PM INF create file path="demo\\testcases\\demo_requests.yml"       
6:47PM INF create file path="demo\\testcases\\demo_ref_testcase.yml"   
6:47PM INF start to create hashicorp python plugin
6:47PM INF create file path="demo\\debugtalk.py"
6:47PM INF ensure python3 venv packages=["funppy"] python3="C:\\Users\\bytedance\\.hrp\\venv\\Scripts\\python3.exe"
6:47PM INF exec command cmd="C:\\Windows\\system32\\cmd.exe /c C:\\Users\\bytedance\\.hrp\\venv\\Scripts\\python3.exe --version"
系统找不到指定的路径。
6:47PM ERR exec command failed error="exit status 1"
6:47PM INF exec command cmd="C:\\Windows\\system32\\cmd.exe /c python3 --version"
Python 3.10.4
6:47PM INF exec command cmd="C:\\Windows\\system32\\cmd.exe /c python3 -m venv --symlinks C:\\Users\\bytedance\\.hrp\\venv"
Unable to symlink 'C:\\Users\\bytedance\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\idle.exe' to 'C:\\Users\\bytedance\\.hrp\\venv\\Scripts\\idle.exe'
Error: [Errno 22] Invalid argument: 'C:\\Users\\bytedance\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\idle.exe'
6:47PM ERR exec command failed error="exit status 1"
6:47PM WRN failed to create python3 .venv by using --symlinks, try to use --copies
6:47PM INF exec command cmd="C:\\Windows\\system32\\cmd.exe /c python3 -m venv --copies C:\\Users\\bytedance\\.hrp\\venv"
6:47PM INF installing python package package=funppy
6:47PM INF exec command cmd="C:\\Windows\\system32\\cmd.exe /c C:\\Users\\bytedance\\.hrp\\venv\\Scripts\\python.exe -m pip install --upgrade funppy --quiet --disable-pip-version-check"
6:47PM INF python package is ready name=funppy version=0.4.5
6:47PM INF create scaffold success projectName=demo
```