### PR TITLE
fix: python exists, but python3 doesn't exist on Windows

### DIFF
--- a/funppy/__init__.py
+++ b/funppy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 
 from funppy.plugin import register, serve
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "funppy"
-version = "0.4.5"
+version = "0.4.6"
 description = "Python plugin over gRPC for funplugin"
 license = "Apache-2.0"
 authors = ["debugtalk <mail@debugtalk.com>"]

--- a/shared/config.go
+++ b/shared/config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 )
 
-const Version = "v0.4.5"
+const Version = "v0.4.6"
 
 // PluginTypeEnvName is used to specify hashicorp go plugin type, rpc/grpc
 const PluginTypeEnvName = "HRP_PLUGIN_TYPE"

--- a/shared/utils_windows.go
+++ b/shared/utils_windows.go
@@ -22,12 +22,17 @@ func EnsurePython3Venv(venvDir string, packages ...string) (python3 string, err 
 		Strs("packages", packages).
 		Msg("ensure python3 venv")
 
+	systemPython := "python3"
+
 	// check if python3 venv is available
 	if err := exec.Command("cmd", "/c", python3, "--version").Run(); err != nil {
 		// python3 venv not available, create one
 		// check if system python3 is available
-		if err := execCommand("python3", "--version"); err != nil {
-			return "", errors.Wrap(err, "python3 not found")
+		if err := execCommand(systemPython, "--version"); err != nil {
+			if err := execCommand("python", "--version"); err != nil {
+				return "", errors.Wrap(err, "python3 not found")
+			}
+			systemPython = "python"
 		}
 
 		// check if .venv exists
@@ -41,10 +46,10 @@ func EnsurePython3Venv(venvDir string, packages ...string) (python3 string, err 
 		// create python3 .venv
 		// notice: --symlinks should be specified for windows
 		// https://github.com/actions/virtual-environments/issues/2690
-		if err := execCommand("python3", "-m", "venv", "--symlinks", venvDir); err != nil {
+		if err := execCommand(systemPython, "-m", "venv", "--symlinks", venvDir); err != nil {
 			// fix: failed to symlink on Windows
 			log.Warn().Msg("failed to create python3 .venv by using --symlinks, try to use --copies")
-			if err := execCommand("python3", "-m", "venv", "--copies", venvDir); err != nil {
+			if err := execCommand(systemPython, "-m", "venv", "--copies", venvDir); err != nil {
 				return "", errors.Wrap(err, "create python3 venv failed")
 			}
 		}


### PR DESCRIPTION
在windows系统中，python默认python3，并不会默认有python3命令，如果同时存在python2，优先级也是python3高