### PR TITLE
fix: enhance compatibility of calling function

### DIFF
--- a/fungo/plugin.go
+++ b/fungo/plugin.go
@@ -51,6 +51,8 @@ func Register(funcName string, fn interface{}) {
 		return
 	}
 	functions[funcName] = reflect.ValueOf(fn)
+	// automatic registration with common name
+	functions[shared.ConvertCommonName(funcName)] = reflect.ValueOf(fn)
 }
 
 // serveRPC starts a plugin server process in RPC mode.

--- a/fungo/plugin.go
+++ b/fungo/plugin.go
@@ -52,7 +52,7 @@ func Register(funcName string, fn interface{}) {
 	}
 	functions[funcName] = reflect.ValueOf(fn)
 	// automatic registration with common name
-	functions[shared.ConvertCommonName(funcName)] = reflect.ValueOf(fn)
+	functions[shared.ConvertCommonName(funcName)] = functions[funcName]
 }
 
 // serveRPC starts a plugin server process in RPC mode.

--- a/funppy/__init__.py
+++ b/funppy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 
 from funppy.plugin import register, serve
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "funppy"
-version = "0.4.6"
+version = "0.4.7"
 description = "Python plugin over gRPC for funplugin"
 license = "Apache-2.0"
 authors = ["debugtalk <mail@debugtalk.com>"]

--- a/shared/config.go
+++ b/shared/config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 )
 
-const Version = "v0.4.6"
+const Version = "v0.4.7"
 
 // PluginTypeEnvName is used to specify hashicorp go plugin type, rpc/grpc
 const PluginTypeEnvName = "HRP_PLUGIN_TYPE"

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -151,3 +151,8 @@ func InstallPythonPackage(python3 string, pkg string) (err error) {
 
 	return nil
 }
+
+// ConvertCommonName returns name which deleted "_" and converted capital letter to their lower case
+func ConvertCommonName(name string) string {
+	return strings.ToLower(strings.Replace(name, "_", "", -1))
+}

--- a/shared/utils_test.go
+++ b/shared/utils_test.go
@@ -206,3 +206,33 @@ func TestCallFuncAbnormal(t *testing.T) {
 	}
 
 }
+
+func TestConvertCommonName(t *testing.T) {
+	testData := []struct {
+		expectedValue string
+		originalValue string
+	}{
+		{
+			expectedValue: "httprunner",
+			originalValue: "HttpRunner",
+		},
+		{
+			expectedValue: "httprunner",
+			originalValue: "http_runner",
+		},
+		{
+			expectedValue: "httprunner",
+			originalValue: "_http_runner",
+		},
+		{
+			expectedValue: "httprunner",
+			originalValue: "HTTP_Runner",
+		},
+	}
+	for _, data := range testData {
+		name := ConvertCommonName(data.originalValue)
+		if !assert.Equal(t, data.expectedValue, name) {
+			t.Fatal()
+		}
+	}
+}


### PR DESCRIPTION
修改：

在使用fungo注册函数时，自动添加函数与无字符“_”、全小写的funplugin通用函数名称。在使用call调用函数时，在搜寻失败时将名称转换为通用函数名称后再搜寻，两次都失败则调用失败。

例如：

注册时使用：
```go
fungo.Register("get_version", GetVersion)
```
则我们使用get_version、GetVersion、getVersion时都可以成功调用