### PR TITLE
fix: check whether the package is installed by importing package

### DIFF
--- a/funppy/__init__.py
+++ b/funppy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 
 from funppy.plugin import register, serve
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "funppy"
-version = "0.4.8"
+version = "0.4.9"
 description = "Python plugin over gRPC for funplugin"
 license = "Apache-2.0"
 authors = ["debugtalk <mail@debugtalk.com>"]

--- a/shared/config.go
+++ b/shared/config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 )
 
-const Version = "v0.4.8"
+const Version = "v0.4.9"
 
 // PluginTypeEnvName is used to specify hashicorp go plugin type, rpc/grpc
 const PluginTypeEnvName = "HRP_PLUGIN_TYPE"

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -133,18 +133,17 @@ func InstallPythonPackage(python3 string, pkg string) (err error) {
 		}
 	}()
 
+	// check if package installed
+	err = exec.Command(python3, "-c", fmt.Sprintf("import %s", pkgName)).Run()
+	if err == nil {
+		return nil
+	}
+
 	// check if pip available
 	err = execCommand(python3, "-m", "pip", "--version")
 	if err != nil {
 		log.Warn().Msg("pip is not available")
 		return errors.Wrap(err, "pip is not available")
-	}
-
-	// check if funppy installed
-	err = execCommand(python3, "-m", "pip", "show", pkgName, "--quiet")
-	if err == nil {
-		// package is installed
-		return nil
 	}
 
 	log.Info().Str("package", pkg).Msg("installing python package")


### PR DESCRIPTION
改为使用import module的形式判断包是否安装，以解决非第三方依赖通过pip去检测安装会失败问题。

如：
```
11:31AM INF exec command cmd="/Users/bytedance/.hrp/venv/bin/python3 -m pip show logging --quiet"
WARNING: Package(s) not found: logging
11:31AM ERR exec command failed error="exit status 1"
```