### PR TITLE
1. 修复在windows环境下 AssertPythonPackage 检查funppy版本执行报错。

### DIFF
--- a/myexec/cmd.go
+++ b/myexec/cmd.go
@@ -59,7 +59,7 @@ func ExecPython3Command(cmdName string, args ...string) error {
 
 func AssertPythonPackage(python3 string, pkgName, pkgVersion string) error {
 	out, err := Command(
-		python3, "-c", fmt.Sprintf("import %s; print(%s.__version__)", pkgName, pkgName),
+		python3, "-c", fmt.Sprintf("\"import %s; print(%s.__version__)\"", pkgName, pkgName),
 	).Output()
 	if err != nil {
 		return fmt.Errorf("python package %s not found", pkgName)


### PR DESCRIPTION
hrp4.3.6初始化失败报错详细信息如下：
[INFO]  fungo: ensure python3 venv: python3=C:\Users\Paolo\.hrp\venv\Scripts\python.exe packages=["funppy"] [INFO]  fungo: exec command: cmd=C:\WINDOWS\system32\cmd.exe [INFO]  fungo: installing python package: pkgName=funppy pkgVersion="" [INFO]  fungo: exec command: cmd=C:\WINDOWS\system32\cmd.exe 2023-09-27T10:50:41.81+08:00 ERR python3 venv is not ready error="pip install funppy failed: python package funppy not found" packages=["funppy"] 2023-09-27T10:50:41.811+08:00 ERR [Run] init case runner failed error="init plugin failed: pip install funppy failed: python package funppy not found: prepare python3 venv failed" Error: init plugin failed: pip install funppy failed: python package funppy not found: prepare python3 venv failed hrp exit 9